### PR TITLE
Fix CHROMA API key fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # ragbot-ai-project
 OpenAI API project with knowledge base
 
-# Steps
-Activate virtual env: by opening Terminal and executing: venv\Scripts\activate 
+## Setup
+
+Before running `prototype.py` ensure that your OpenAI API key is available to
+the application. The script will look for either `CHROMA_OPENAI_API_KEY` (the
+default expected by `chromadb`) or `OPENAI_API_KEY`. Define one of these
+environment variables with your key, for example:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+### Steps
+Activate the virtual environment by executing `venv\Scripts\activate` (or the
+equivalent command on your platform).

--- a/prototype.py
+++ b/prototype.py
@@ -6,8 +6,18 @@ import httpx
 
 #BASE_URL = "myurl.com"
 
-API_KEY = os.getenv("OPENAI_API_KEY")
-CHROMA_OPENAI_API_KEY = os.getenv("CHROMA_OPENAI_API_KEY")
+# Attempt to read the OpenAI API key from either environment variable.
+# chromadb by default looks for ``CHROMA_OPENAI_API_KEY`` while other
+# tooling commonly uses ``OPENAI_API_KEY``. To avoid runtime errors when
+# only one of these variables is defined, check both and fall back to the
+# other when necessary.
+API_KEY = os.getenv("CHROMA_OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+
+if not API_KEY:
+    raise EnvironmentError(
+        "Set CHROMA_OPENAI_API_KEY or OPENAI_API_KEY environment variable"
+    )
+
 
 #CA_BUNDLE_PATH = os.getenv("CA_BUNDLE_PATH")
 


### PR DESCRIPTION
## Summary
- read API key from either `CHROMA_OPENAI_API_KEY` or `OPENAI_API_KEY`
- document the environment variable requirement in README

## Testing
- `python -m py_compile prototype.py`
- `python prototype.py 2>&1 | head -n 5`